### PR TITLE
fix: Avoid using /tmp in Dockerfile for compatibility with Singularity

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -7,13 +7,13 @@ apt-get install -y libpng16-16 ;\
 apt-get install -y libopenexr22 ;\
 
 # We will mount the host input dir in this directory.
-INPUTS=/tmp/inputs ;\
-OUTPUTS=/tmp/outputs ;\
+INPUTS=/home/inputs ;\
+OUTPUTS=/home/outputs ;\
 #make sure the user running the algorithm can read
 mkdir $INPUTS ;\
 #make sure the user running the algorithm can read and write
 mkdir $OUTPUTS ;
 
-ADD ./build/commandLineCli /tmp/commandLineCli
+ADD ./build/commandLineCli /home/commandLineCli
 
-ENTRYPOINT ["/tmp/commandLineCli"]
+ENTRYPOINT ["/home/commandLineCli"]


### PR DESCRIPTION
I've been testing WIPP plugins using [Singularity](https://sylabs.io/singularity/) container runtime which is often used on HPC clusters instead of Docker. Singularity uses `/tmp` for its [own purposes](https://sylabs.io/guides/3.5/user-guide/build_env.html#temporary-folders), so I propose moving executable from `/tmp` to '/home'.